### PR TITLE
fix(dtso): ac209a display

### DIFF
--- a/conf/machine/am62-phyverso-evcs.conf
+++ b/conf/machine/am62-phyverso-evcs.conf
@@ -11,8 +11,8 @@ KERNEL_DEVICETREE = " \
     ti/k3-am625-phyverso-evcs.dtb \
     ti/dd0700mc01_lvds.dtbo \
     ti/dd0700mc01_dpi.dtbo \
-    ti/k3-am62-phyboard-lyra-oldi-ac209a.dtbo \
     ti/cc33xx.dtbo \
+    ti/k3-am62-oldi-ac209a.dtbo \
 "
 
 EMMC_DEV = "0"

--- a/recipes-kernel/linux/linux-phytec-ti_6.6.58-10.01.10%.bbappend
+++ b/recipes-kernel/linux/linux-phytec-ti_6.6.58-10.01.10%.bbappend
@@ -29,6 +29,8 @@ do_compile:prepend () {
        "${STAGING_KERNEL_DIR}/arch/${ARCH}/boot/dts/ti/"
                 cp "${WORKDIR}/cc33xx.dtso" \
        "${STAGING_KERNEL_DIR}/arch/${ARCH}/boot/dts/ti/"
+                cp "${WORKDIR}/k3-am62-oldi-ac209a.dtso" \
+       "${STAGING_KERNEL_DIR}/arch/${ARCH}/boot/dts/ti/"
 }
 
 


### PR DESCRIPTION
dtso is currently not added to kernel `${STAGING_KERNEL_DIR}/arch/${ARCH}/boot/dts/ti/` directory, therefore could not be found to be automatically compiled to dtbo. Respective dtbo also needs adding in machine conf to be added to final image.